### PR TITLE
Fix Nhentai service

### DIFF
--- a/app/src/main/java/com/ensoft/imgurviewer/service/resource/NhentaiService.java
+++ b/app/src/main/java/com/ensoft/imgurviewer/service/resource/NhentaiService.java
@@ -12,16 +12,18 @@ import com.ensoft.imgurviewer.service.listener.PathResolverListener;
 import com.ensoft.restafari.network.processor.ResponseListener;
 import com.ensoft.restafari.network.service.RequestService;
 
-import java.util.ArrayList;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class NhentaiService extends MediaServiceSolver implements AlbumProvider {
 
-    public static final String BASE_IMG_URL = "https://i.nhentai.net/galleries/";
-    public static final String BASE_THUMB_URL = "https://t.nhentai.net/galleries/";
     public static final String DOMAIN = "nhentai.net";
-    public static final String IMAGE_REGEX = "<img src=\"https://t.nhentai.net/galleries/(\\d+/\\d+)t.jpg";
+    private static final String NHENTAI_URL_REGEX = "https://nhentai\\.net/g/(\\d+)/";
+    private static final String API_BASE = "https://janda.mod.land/nhentai/get?book=";
 
     @Override
     public void getPath(Uri uri, PathResolverListener pathResolverListener) {
@@ -30,27 +32,54 @@ public class NhentaiService extends MediaServiceSolver implements AlbumProvider 
 
     @Override
     public void getAlbum(Uri uri, AlbumSolverListener albumSolverListener) {
-        RequestService.getInstance().makeStringRequest(Request.Method.GET, uri.toString(), new ResponseListener<String>() {
+        // Make a regex pattern to
+        Pattern regex = Pattern.compile(NHENTAI_URL_REGEX);
+        Matcher matcher = regex.matcher(uri.toString());
+
+        // Check if the regex matches. If it doesn't then this URL is invalid.
+        if (!matcher.find()) {
+            albumSolverListener.onAlbumError("URL is not a valid album.");
+            return;
+        }
+
+        // Grab the album id from the match
+        final String albumId = matcher.group(1);
+
+        // Make a request to the intermediary API
+        String apiUrl = API_BASE + albumId;
+        RequestService.getInstance().makeStringRequest(Request.Method.GET, apiUrl, new ResponseListener<String>() {
             @Override
             public void onRequestSuccess(Context context, String response) {
-                final Pattern pattern = Pattern.compile(IMAGE_REGEX, Pattern.MULTILINE);
-                final Matcher matcher = pattern.matcher(response);
+                try {
+                    // Parse the JSON result and get the image list
+                    JSONObject data = new JSONObject(response).getJSONObject("data");
+                    JSONArray imageUrls = data.optJSONArray("image");
 
-                ArrayList<ImgurImage> images = new ArrayList<>();
-                while (matcher.find()) {
-                    String id = matcher.group(1);
-                    Uri thumbnail = Uri.parse(BASE_THUMB_URL + id + "t.jpg");
-                    images.add(new ImgurImage(id, BASE_IMG_URL + id + ".jpg", thumbnail, null));
+                    // Make sure we actually got some images
+                    if (imageUrls == null) {
+                        albumSolverListener.onAlbumError("Server returned no images.");
+                        return;
+                    }
+
+                    // Iterate over the images in the returned response and add them to the album
+                    ImgurImage[] album = new ImgurImage[imageUrls.length()];
+                    for (int i = 0; i < imageUrls.length(); i++) {
+                        String imageUrl = imageUrls.getString(i);
+                        String thumbnailUrl = imageUrl.replace("i.nhentai", "t.nhentai").replace(".jpg", "t.jpg");
+                        album[i] = new ImgurImage(albumId + "/" + i, imageUrl, Uri.parse(thumbnailUrl), null);
+                    }
+
+                    // Return the album
+                    albumSolverListener.onAlbumResolved(album);
+
+                } catch (JSONException e) {
+                    albumSolverListener.onAlbumError("Server returned bad JSON data.");
                 }
-
-                ImgurImage[] album = new ImgurImage[images.size()];
-                album = images.toArray(album);
-                albumSolverListener.onAlbumResolved(album);
             }
 
             @Override
             public void onRequestError(Context context, int errorCode, String errorMessage) {
-                albumSolverListener.onAlbumError(errorCode + ": Could not load album");
+                albumSolverListener.onAlbumError(errorCode + ": " + errorMessage);
             }
         });
     }


### PR DESCRIPTION
Some time ago Nhentai started using Cloudflare on their site which prevented the current handler from scraping for the images. This fix uses the intermediary API service [Jandapress](https://github.com/sinkaroid/jandapress) to query for the images instead.