### PR TITLE
Fix color banding

### DIFF
--- a/app/src/main/java/com/ensoft/imgurviewer/view/fragment/ImageViewerFragment.java
+++ b/app/src/main/java/com/ensoft/imgurviewer/view/fragment/ImageViewerFragment.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
+import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.Point;
 import android.graphics.drawable.Animatable;
@@ -26,6 +27,11 @@ import android.widget.ProgressBar;
 import android.widget.Toast;
 
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView;
+import com.davemorrissey.labs.subscaleview.decoder.CompatDecoderFactory;
+import com.davemorrissey.labs.subscaleview.decoder.ImageDecoder;
+import com.davemorrissey.labs.subscaleview.decoder.ImageRegionDecoder;
+import com.davemorrissey.labs.subscaleview.decoder.SkiaImageDecoder;
+import com.davemorrissey.labs.subscaleview.decoder.SkiaImageRegionDecoder;
 import com.ensoft.imgurviewer.App;
 import com.ensoft.imgurviewer.model.MediaType;
 import com.ensoft.imgurviewer.service.DownloadService;
@@ -427,7 +433,11 @@ public class ImageViewerFragment extends Fragment
 		imageView.setOnClickListener( v -> onImageClick() );
 		
 		if ( imageView.getSSIV() != null )
+		{
 			imageView.getSSIV().setMaxScale( 10 );
+			imageView.getSSIV().setBitmapDecoderFactory(new CompatDecoderFactory<ImageDecoder>(SkiaImageDecoder.class, Bitmap.Config.ARGB_8888));
+			imageView.getSSIV().setRegionDecoderFactory(new CompatDecoderFactory<ImageRegionDecoder>(SkiaImageRegionDecoder.class, Bitmap.Config.ARGB_8888));
+		}
 		
 		imageView.setImageLoaderCallback( new ImageLoader.Callback()
 		{


### PR DESCRIPTION
Fix #27 

This will cause increased memory usage, but also improves color accuracy.
Maybe it's desired to turn this into a setting, but I don't know how to do this.

See this page for more details: https://github.com/davemorrissey/subsampling-scale-image-view/wiki/02.-Displaying-images#important-notes

This image can be used for testing: https://i.imgur.com/v0NcJ4D.png