### PR TITLE
Added support for kick.com clips and fixed occasional crashes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -621,6 +621,18 @@
 				<category android:name="android.intent.category.DEFAULT" />
 				<category android:name="android.intent.category.BROWSABLE" />
 
+				<data android:host="kick.com" />
+
+				<data android:scheme="https" />
+				<data android:scheme="http" />
+
+				<data android:pathPattern="/.*" />
+			</intent-filter>
+			<intent-filter>
+				<action android:name="android.intent.action.VIEW" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<category android:name="android.intent.category.BROWSABLE" />
+
 				<data android:host="cdn.discordapp.com" />
 				<data android:host="cdn.cloudflare.steamstatic.com" />
 

--- a/app/src/main/java/com/ensoft/imgurviewer/model/KickClip.java
+++ b/app/src/main/java/com/ensoft/imgurviewer/model/KickClip.java
@@ -1,0 +1,14 @@
+package com.ensoft.imgurviewer.model;
+
+import com.google.gson.annotations.SerializedName;
+
+public class KickClip {
+
+    @SerializedName( "video_url" )
+    protected String url;
+
+    public String getVideoUrl() {
+        return url;
+    }
+
+}

--- a/app/src/main/java/com/ensoft/imgurviewer/model/KickClipResponse.java
+++ b/app/src/main/java/com/ensoft/imgurviewer/model/KickClipResponse.java
@@ -1,0 +1,10 @@
+package com.ensoft.imgurviewer.model;
+
+import com.google.gson.annotations.SerializedName;
+
+public class KickClipResponse {
+
+    @SerializedName( "clip" )
+    public KickClip clip;
+
+}

--- a/app/src/main/java/com/ensoft/imgurviewer/service/ResourceSolver.java
+++ b/app/src/main/java/com/ensoft/imgurviewer/service/ResourceSolver.java
@@ -17,6 +17,7 @@ import com.ensoft.imgurviewer.service.resource.IbbCoService;
 import com.ensoft.imgurviewer.service.resource.ImgFlipService;
 import com.ensoft.imgurviewer.service.resource.ImgurService;
 import com.ensoft.imgurviewer.service.resource.InstagramService;
+import com.ensoft.imgurviewer.service.resource.KickService;
 import com.ensoft.imgurviewer.service.resource.MediaServiceSolver;
 import com.ensoft.imgurviewer.service.resource.NhentaiService;
 import com.ensoft.imgurviewer.service.resource.PornHubService;
@@ -111,6 +112,7 @@ public class ResourceSolver
 		addSolver( new TwimgPBSService() );
 		addSolver( new StreamffService() );
 		addSolver( new ArazuService() );
+		addSolver( new KickService() );
 		addSolver( new GenericServiceSolver() );
 	}
 	

--- a/app/src/main/java/com/ensoft/imgurviewer/service/resource/KickService.java
+++ b/app/src/main/java/com/ensoft/imgurviewer/service/resource/KickService.java
@@ -1,0 +1,56 @@
+package com.ensoft.imgurviewer.service.resource;
+
+import android.content.Context;
+import android.net.Uri;
+
+import com.android.volley.Request;
+import com.ensoft.imgurviewer.model.KickClipResponse;
+import com.ensoft.imgurviewer.service.UriUtils;
+import com.ensoft.imgurviewer.service.listener.PathResolverListener;
+import com.ensoft.restafari.network.processor.ResponseListener;
+import com.ensoft.restafari.network.service.RequestService;
+
+
+public class KickService extends MediaServiceSolver {
+
+    protected static final String KICK_DOMAIN = "kick.com";
+    protected static final String CLIP_ENDPOINT = "/api/v2/clips/";
+
+    protected String getClipId( Uri uri ) {
+        return uri.getQueryParameter( "clip" );
+    }
+
+    @Override
+    public void getPath(Uri uri, PathResolverListener pathResolverListener) {
+        String url = "https://" + KICK_DOMAIN + CLIP_ENDPOINT + getClipId(uri);
+        RequestService.getInstance().makeJsonRequest(Request.Method.GET, url, new ResponseListener<KickClipResponse>() {
+            @Override
+            public void onRequestSuccess(Context context, KickClipResponse r) {
+                Uri url = Uri.parse(r.clip.getVideoUrl());
+                pathResolverListener.onPathResolved( url, UriUtils.guessMediaTypeFromUri( url ), uri );
+            }
+
+            @Override
+            public void onRequestError(Context context, int errorCode, String errorMessage) {
+                pathResolverListener.onPathError(uri, errorMessage);
+            }
+        });
+    }
+
+    @Override
+    public boolean isServicePath(Uri uri) {
+        String scheme = uri.getScheme();
+        if ( scheme == null || ( !scheme.equals("http") && !scheme.equals("https") ) )
+            return false;
+        String host = uri.getHost();
+        if ( host == null || !host.equals(KICK_DOMAIN) )
+            return false;
+        return getClipId(uri) != null;
+    }
+
+    @Override
+    public boolean isGallery(Uri uri) {
+        return false;
+    }
+
+}

--- a/app/src/main/java/com/ensoft/imgurviewer/view/activity/AlbumPagerActivity.java
+++ b/app/src/main/java/com/ensoft/imgurviewer/view/activity/AlbumPagerActivity.java
@@ -45,7 +45,8 @@ public class AlbumPagerActivity extends AppActivity implements AlbumPagerProvide
 	protected void onCreate( Bundle savedInstanceState )
 	{
 		super.onCreate( savedInstanceState );
-		
+
+		App.getInstance().waitForInitialization();
 		setContentView( R.layout.activity_albumpager );
 		
 		pager = findViewById( R.id.view_pager );

--- a/app/src/main/java/com/ensoft/imgurviewer/view/activity/ImageViewer.java
+++ b/app/src/main/java/com/ensoft/imgurviewer/view/activity/ImageViewer.java
@@ -26,7 +26,8 @@ public class ImageViewer extends AppActivity
 	protected void onCreate( Bundle savedInstanceState )
 	{
 		super.onCreate( savedInstanceState );
-		
+
+		App.getInstance().waitForInitialization();
 		setContentView( R.layout.activity_imageviewer );
 	}
 	

--- a/app/src/main/java/com/ensoft/imgurviewer/view/activity/ImgurAlbumGalleryViewer.java
+++ b/app/src/main/java/com/ensoft/imgurviewer/view/activity/ImgurAlbumGalleryViewer.java
@@ -58,7 +58,8 @@ public class ImgurAlbumGalleryViewer extends AppActivity
 	public void onCreate( Bundle savedInstanceState )
 	{
 		super.onCreate( savedInstanceState );
-		
+
+		App.getInstance().waitForInitialization();
 		setContentView( R.layout.activity_albumviewer );
 		
 		progressBar = findViewById( R.id.albumViewer_progressBar );


### PR DESCRIPTION
* I've added support for clips from kick.com
* I investigated some crashes that I've experienced and I believe https://github.com/facebook/fresco/issues/293 is the cause. The response was "Fresco.initialize needs to be called before setContentView in your app." so I've added some code that waits for init thread to finish before calling `setContentView`. This seems to have fixed the crashes for me.